### PR TITLE
run-drc-for-cell-gds-using-magic: Use docker/metadata-action@v3

### DIFF
--- a/.github/workflows/build-docker-image-run-drc-for-cell-gds-using-magic.yml
+++ b/.github/workflows/build-docker-image-run-drc-for-cell-gds-using-magic.yml
@@ -104,10 +104,15 @@ jobs:
 
     - name: Docker meta
       id: docker_meta
-      uses: crazy-max/ghaction-docker-meta@v1
+      uses: docker/metadata-action@v3
       with:
         images: ${{ steps.push_to.outputs.images }}
-        tag-sha: true
+        tags: |
+          type=ref,event=tag
+          type=ref,event=pr
+          type=ref,event=branch
+          type=sha
+          type=sha,format=long
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1


### PR DESCRIPTION
Change from `crazy-max/ghaction-docker-meta@v1` to the now official
`docker/metadata-action@v3`.

Signed-off-by: Tim 'mithro' Ansell <tansell@google.com>