### PR TITLE
Change back to upstream docker/metadata-action.

### DIFF
--- a/.github/workflows/build-docker-image-run-drc-for-cell-gds-using-magic.yml
+++ b/.github/workflows/build-docker-image-run-drc-for-cell-gds-using-magic.yml
@@ -117,7 +117,7 @@ jobs:
 
     - name: Docker meta
       id: docker_meta
-      uses: mithro/docker-metadata-action@master
+      uses: docker/metadata-action@v3
       with:
         images: ${{ steps.push_to.outputs.images }}
         tags: |


### PR DESCRIPTION
Upstream has fixed https://github.com/docker/metadata-action/issues/90
(the issue with pull_request_target not working), we can use it again.

Signed-off-by: Tim 'mithro' Ansell <tansell@google.com>